### PR TITLE
Remove noisy prints

### DIFF
--- a/zoidberg/boundary.py
+++ b/zoidberg/boundary.py
@@ -1,6 +1,4 @@
-"""Boundary objects that define an 'outside'
-
-"""
+"""Boundary objects that define an 'outside'"""
 
 import numpy as np
 

--- a/zoidberg/zoidberg.py
+++ b/zoidberg/zoidberg.py
@@ -217,7 +217,7 @@ def get_metric(grid, magnetic_field):
     # Get magnetic field and pressure
     Bmag = np.zeros(grid.shape)
     pressure = np.zeros(grid.shape)
-    print("starting Bfield stuff")
+
     for yindex in range(grid.numberOfPoloidalGrids()):
         pol_grid, ypos = grid.getPoloidalGrid(yindex)
         Bmag[:, yindex, :] = magnetic_field.Bmag(pol_grid.R, pol_grid.Z, ypos)
@@ -225,7 +225,6 @@ def get_metric(grid, magnetic_field):
         By = magnetic_field.Byfunc(pol_grid.R, pol_grid.Z, ypos)
         metric["g_yy"][:, yindex, :] *= (Bmag[:, yindex, :] / By) ** 2
         metric["gyy"][:, yindex, :] *= (By / Bmag[:, yindex, :]) ** 2
-    print("done Bfield stuff")
 
     return metric, Bmag, pressure
 


### PR DESCRIPTION
These were making some BOUT++ tests a bit too noisy. We could replace these with `logging` if required