### PR TITLE
Use traced parallel length for Dommaschk metric/J validation

### DIFF
--- a/zoidberg/diff.py
+++ b/zoidberg/diff.py
@@ -57,7 +57,6 @@ def c4(f, axis, periodic=False):
     slc = [slice(None) for _ in f.shape]
 
     slc[axis] = slice(2, -2)
-    # out[t(slc)] = 0.083333333333333333 * fi(-2) + -0.66666666666666666 * fi(-1) + 0.66666666666666666 * fi(1) + -0.08333333333333333 * fi(2)
     out[t(slc)] = (-fi(2) + 8 * fi(1) - 8 * fi(-1) + fi(-2)) / 12
 
     slc[axis] = 0
@@ -96,3 +95,35 @@ def c4(f, axis, periodic=False):
         + 2.08333333333333333 * fi(0)
     )
     return out
+
+
+def field_line_length(RZ_coords, y_coords, refine=100):
+    """
+    This function takes the trace from a field line tracer and calculate
+    the length along the points.
+
+    This is done by interpolating the points in cylindircal coordinates using
+    a spline. Then the line is transformed to cartesian coordinates, where the
+    sum of the point wise distance is computed.
+    """
+    from scipy.interpolate import CubicSpline as interp
+
+    assert RZ_coords.shape[-1] == 2
+    RZ_coords = RZ_coords[..., 0], RZ_coords[..., 1]
+
+    y_inter = interp(np.linspace(0, 1, len(y_coords)), y_coords)
+
+    y_fine = y_inter(np.linspace(0, 1, (len(y_coords) - 1) * refine + 1))
+    R_fine, Z_fine = [interp(y_coords, x)(y_fine) for x in RZ_coords]
+
+    slicer = [None for _ in R_fine.shape]
+    slicer[0] = slice(None, None)
+    y_fine = y_fine[tuple(slicer)]
+
+    X_fine = np.cos(y_fine) * R_fine
+    Y_fine = np.sin(y_fine) * R_fine
+
+    dXYZs = [(x[1:] - x[:-1]) ** 2 for x in [X_fine, Y_fine, Z_fine]]
+    ds2 = np.sum(dXYZs, axis=0)
+    ds = np.sqrt(ds2)
+    return np.sum(ds, axis=0)

--- a/zoidberg/test_volume_dommaschk.py
+++ b/zoidberg/test_volume_dommaschk.py
@@ -1,0 +1,292 @@
+import os
+
+import numpy as np
+import scipy
+import xarray as xr
+from shapely.geometry import Polygon
+
+from . import field as zbfield
+from . import fieldtracer
+from . import grid as zbgrid
+from . import poloidal_grid, rzline, zoidberg
+
+script_dir = os.getcwd()
+
+
+def calc_divertortheta(x, z, x0=0.0):
+    theta = np.array(np.arctan2(z, x - x0))
+    theta[theta < 0.0] += 2.0 * np.pi
+    return theta
+
+
+def dommaschk_grid_volume(
+    nx, ny, nz, a1, a2, R0, Btor, symmetry, yperiod, plotting=False
+):
+
+    C = np.zeros((6, 3, 4))
+    C[5, 2, 1] = -1.489
+    C[5, 2, 2] = -1.489
+    field = zbfield.DommaschkPotentials(C, R_0=R0, B_0=Btor)
+    y_grid = np.linspace(0.0, yperiod, ny, endpoint=False)
+
+    rzcoord, _ = fieldtracer.trace_poincare(
+        field,
+        (a1, a2),
+        0.0,
+        2.0 * np.pi / symmetry,
+        y_slices=y_grid,
+        revs=200,
+        nplot=1,
+        nover=20,
+    )
+    inner_lines = []
+    outer_lines = []
+    pol_grids = []
+    for i in range(ny):
+
+        inner_line = rzline.line_from_points(
+            rzcoord[:, i, 0, 0], rzcoord[:, i, 0, 1], spline_order=1
+        )
+        outer_line = rzline.line_from_points(
+            rzcoord[:, i, 1, 0], rzcoord[:, i, 1, 1], spline_order=1
+        )
+
+        inner_line = inner_line.equallySpaced(n=nz // 4)
+        outer_line = outer_line.equallySpaced(n=nz // 4)
+
+        inner_lines.append(inner_line)
+        outer_lines.append(outer_line)
+
+        pol_grid = poloidal_grid.grid_elliptic(
+            inner_lines[i],
+            outer_lines[i],
+            nx,
+            nz,
+            restrict_size=2560,
+            align=0,
+            inner_ort=1,
+            inner_maxmode=4,
+            nx_inner=0,
+            nx_outer=0,
+        )
+        pol_grids.append(pol_grid)
+        if plotting:
+            import matplotlib.pyplot as plt
+
+            fig, ax = plt.subplots(figsize=(8, 8), dpi=400)
+            pol_grid.plot(axis=ax, show=False)
+            ax.set_aspect("equal")
+            ax.grid(True, zorder=0)
+            ax.set_xlim(1.6, 2.4)
+            ax.set_ylim(-0.3, 0.3)
+            plt.show()
+
+    grid = zbgrid.Grid(pol_grids, y_grid, 2.0 * np.pi / symmetry, yperiodic=True)
+    maps = zoidberg.make_maps(grid, field, nslice=1, num=10)
+
+    filename = os.path.join(script_dir, f"dommaschk_testgrid_{nx}_{ny}_{nz}.nc")
+    zoidberg.write_maps(grid, field, maps, metric2d=False, gridfile=filename)
+    gf = xr.open_dataset(filename)
+    cellvolumes = (gf["J"] * gf["dx"] * gf["dy"] * gf["dz"]).values
+    gridvolume = np.sum(cellvolumes)
+    return gridvolume
+
+
+def torus_volume_from_sections_periodic(polygons, angles, symmetry, mode=0):
+
+    V = 0.0
+    N = len(polygons)
+    if mode == 0:
+        for i in range(N):
+            j = (i + 1) % N  # wrap around
+
+            A1 = polygons[i].area
+            A2 = polygons[j].area
+
+            R1 = polygons[i].centroid.x
+            R2 = polygons[j].centroid.x
+
+            # Handle final interval correctly
+            if j == 0:
+                dphi = (2 * np.pi / symmetry - angles[i]) + angles[0]
+            else:
+                dphi = angles[j] - angles[i]
+
+            V += 0.5 * (A1 * R1 + A2 * R2) * dphi
+
+        return V
+    elif mode == 1:
+        dphi = np.mean(np.diff(angles))
+        for i in range(N):
+            R1 = polygons[i].centroid.x
+            dl = 2.0 * np.pi * R1 * (dphi / (2.0 * np.pi))
+            V += dl * polygons[i].area
+        return V
+
+
+def calculate_dommaschk_volume(
+    ny, revs, symmetry, yperiod, plotting, Btor, R0, a1, a2, mode=1
+):
+    C = np.zeros((6, 3, 4))
+
+    C[5, 2, 1] = -1.489
+    C[5, 2, 2] = -1.489
+
+    field = zbfield.DommaschkPotentials(C, R_0=R0, B_0=Btor)
+    y_grid = np.linspace(0.0, yperiod, ny, endpoint=False)
+
+    rzcoord, _ = fieldtracer.trace_poincare(
+        field,
+        (a1, a2),
+        0.0,
+        2.0 * np.pi / symmetry,
+        y_slices=y_grid,
+        revs=revs,
+        nplot=1,
+        nover=20,
+    )
+
+    inner_R = rzcoord[:, :, 0, 0]
+    inner_Z = rzcoord[:, :, 0, 1]
+
+    outer_R = rzcoord[:, :, -1, 0]
+    outer_Z = rzcoord[:, :, -1, 1]
+
+    inner_radius = np.sqrt((inner_R - R0) ** 2 + inner_Z**2)
+    outer_radius = np.sqrt((outer_R - R0) ** 2 + outer_Z**2)
+    inner_theta = calc_divertortheta(inner_R, inner_Z, R0)
+    outer_theta = calc_divertortheta(outer_R, outer_Z, R0)
+
+    inner_newR = np.zeros(inner_R.shape)
+    inner_newZ = np.zeros(inner_R.shape)
+
+    outer_newR = np.zeros(inner_R.shape)
+    outer_newZ = np.zeros(inner_R.shape)
+
+    newthetas = np.linspace(0.0, 2.0 * np.pi, revs, endpoint=False)
+
+    cross_area = np.zeros(ny)
+    all_inner_poly = []
+    all_outer_poly = []
+    for i in range(ny):
+        interp_inner = scipy.interpolate.interp1d(
+            inner_theta[:, i],
+            inner_radius[:, i],
+            fill_value="extrapolate",
+            kind="linear",
+        )
+        interp_outer = scipy.interpolate.interp1d(
+            outer_theta[:, i],
+            outer_radius[:, i],
+            fill_value="extrapolate",
+            kind="linear",
+        )
+
+        inner_newradius = interp_inner(newthetas)
+        outer_newradius = interp_outer(newthetas)
+
+        inner_newR[:, i] = inner_newradius * np.cos(newthetas) + R0
+        inner_newZ[:, i] = inner_newradius * np.sin(newthetas)
+
+        outer_newR[:, i] = outer_newradius * np.cos(newthetas) + R0
+        outer_newZ[:, i] = outer_newradius * np.sin(newthetas)
+
+        inner_poly = Polygon(np.column_stack((inner_newR[:, i], inner_newZ[:, i])))
+        outer_poly = Polygon(np.column_stack((outer_newR[:, i], outer_newZ[:, i])))
+
+        all_inner_poly.append(inner_poly)
+        all_outer_poly.append(outer_poly)
+
+        cross_area[i] = outer_poly.area - inner_poly.area
+        if plotting:
+            import matplotlib.pyplot as plt
+
+            fig, ax = plt.subplots()
+            for poly in (inner_poly, outer_poly):
+                x, y = poly.exterior.xy
+                ax.plot(x, y, color="yellow")
+            ax.scatter(
+                inner_R[:, i], inner_Z[:, i], edgecolor="None", color="black", s=2.0
+            )
+            ax.scatter(
+                outer_R[:, i], outer_Z[:, i], edgecolor="None", color="black", s=2.0
+            )
+            ax.scatter(
+                inner_newR[:, i], inner_newZ[:, i], edgecolor="None", color="red", s=1.0
+            )
+            ax.scatter(
+                outer_newR[:, i], outer_newZ[:, i], edgecolor="None", color="red", s=1.0
+            )
+            ax.set_aspect("equal")
+            ax.grid(True)
+            ax.set_ylim(-0.4, 0.4)
+            ax.set_xlim(1.7, 2.3)
+            plt.show()
+
+    outer_volume = torus_volume_from_sections_periodic(
+        all_outer_poly, y_grid, symmetry, mode=mode
+    )
+    inner_volume = torus_volume_from_sections_periodic(
+        all_inner_poly, y_grid, symmetry, mode=mode
+    )
+    return outer_volume - inner_volume
+
+
+# %%
+
+
+def test_run():
+    Btor = 2.5
+    R0 = 2.0
+    a1 = R0 + 0.03
+    a2 = R0 + 0.08
+
+    symmetry = 5.0
+    yperiod = 2.0 * np.pi / symmetry
+    plotting = False
+
+    # First do the exact calculation
+
+    exact_volume = calculate_dommaschk_volume(
+        2000, 500, symmetry, yperiod, plotting, Btor, R0, a1, a2, mode=1
+    )
+    print(f"Exact volume: {np.round(exact_volume,6)} m^3")
+
+    scales = [2, 4, 8]
+    gridvolumes = np.zeros(len(scales))
+
+    for i in range(len(scales)):
+        scale = scales[i]
+        ny = 2 * scale
+        nx = 8 * scale
+        nz = 32 * scale
+        gridvolumes[i] = dommaschk_grid_volume(
+            nx, ny, nz, a1, a2, R0, Btor, symmetry, yperiod, plotting=plotting
+        )
+        print(f"Grid volume: {np.round(gridvolumes[i],6)} m^3")
+    error = np.abs(gridvolumes - exact_volume)
+    print("Error:", error)
+    coeffs = np.polyfit(np.log(scales), np.log(error), 1)
+    a, b = coeffs
+    print("Convergence:", -a)
+
+    if plotting:
+        import matplotlib.pyplot as plt
+
+        x = np.linspace(1.0, 50, 100)
+        fig, ax = plt.subplots()
+        ax.plot(scales, gridvolumes - exact_volume)
+        ax.scatter(scales, np.abs(gridvolumes - exact_volume))
+        ax.plot(x, 0.1 * np.power(x, -1), label=r"nx^-2")
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+        ax.grid(True)
+        ax.set_xlabel(r"$n_x \propto n_y \propto n_z$")
+        ax.set_ylabel(r"Error")
+        plt.show()
+
+    assert a <= -0.9
+
+
+if __name__ == "__main__":
+    test_run()

--- a/zoidberg/zoidberg.py
+++ b/zoidberg/zoidberg.py
@@ -8,6 +8,8 @@ from boututils import datafile as bdata
 from zoidberg import __version__
 
 from . import fieldtracer
+from .diff import field_line_length
+from .field import Slab
 from .grid import Grid
 from .poloidal_grid import StructuredPoloidalGrid
 
@@ -40,12 +42,27 @@ def parallel_slice_field_name(field, offset):
         Parallel slice offset
 
     """
+    absoffset = abs(offset)
+    if absoffset < 1:
+        assert (
+            abs(absoffset - 0.5) < 1e-6
+        ), f"Expected an offset of +- 0.5 but got {offset}"
+        prefix = "low" if offset < 0 else "high"
+        return f"{field}_cell_y{prefix}"
     prefix = "forward" if offset > 0 else "backward"
-    suffix = "_{}".format(abs(offset)) if abs(offset) > 1 else ""
-    return "{}_{}{}".format(prefix, field, suffix)
+    suffix = f"_{absoffset}" if abs(offset) > 1 else ""
+    return f"{prefix}_{field}{suffix}"
 
 
-def make_maps(grid, magnetic_field, nslice=1, quiet=False, field_tracer=None, **kwargs):
+def make_maps(
+    grid,
+    magnetic_field,
+    nslice=1,
+    quiet=False,
+    field_tracer=None,
+    refine_parallel_integral=20,
+    **kwargs,
+):
     """Make the forward and backward FCI maps
 
     Parameters
@@ -58,6 +75,11 @@ def make_maps(grid, magnetic_field, nslice=1, quiet=False, field_tracer=None, **
         Number of parallel slices in each direction
     quiet : bool
         Don't display progress bar
+    field_tracer:
+        Specify a field tracer, otherwise use standard tracer for the
+        given field
+    refine_parallel_integral:
+        The number of intermediate points for g_22 calculation
     kwargs
         Optional arguments for field line tracing, etc.
 
@@ -111,7 +133,7 @@ def make_maps(grid, magnetic_field, nslice=1, quiet=False, field_tracer=None, **
     # Loop over offsets {1, ... nslice, -1, ... -nslice}
     for direction in 1, -1:
         parallel_slices_list.append([])
-        for absoffset in range(1, nslice + 1):
+        for absoffset in [0.5, *range(1, nslice + 1)]:
             offset = absoffset * direction
             # Unique names of the field line maps for this offset
             field_names = [
@@ -131,7 +153,6 @@ def make_maps(grid, magnetic_field, nslice=1, quiet=False, field_tracer=None, **
     total_work = len(parallel_slices_list) * ny
 
     # TODO: if axisymmetric, don't loop, do one slice and copy
-    # TODO: restart tracing for adjacent offsets
     if (not quiet) and (ny > 1):
         if tqdm:
             prog = tqdm(total=total_work, desc="Tracing")
@@ -186,7 +207,92 @@ def make_maps(grid, magnetic_field, nslice=1, quiet=False, field_tracer=None, **
                     prog.update()
                 else:
                     update_progress((slice_index * ny + j + 1) / total_work, **kwargs)
+    for k in list(maps.keys()):
+        if "_cell_y" in k and "t_prime" in k:
+            del maps[k]
 
+    # We could probably skip a lot of the compuation for slab grids
+    prog = None
+    if (not quiet) and (ny > 1):
+        if tqdm:
+            prog = tqdm(total=total_work, desc="Tracing for J")
+        else:
+            update_progress(0, **kwargs)
+
+    jacobian = np.empty(shape)
+    sg_22 = [np.empty(shape) for _ in range(3)]
+    B_cell = [np.empty(shape) for _ in range(3)]
+
+    for j in range(ny):
+        coords = None
+        y_all = None
+        pol, ycoord = grid.getPoloidalGrid(j)
+
+        for direction in [-1, +1]:
+            # Get this poloidal grid
+            _, ycoordnext = grid.getPoloidalGrid(j + direction)
+
+            # Get the next poloidal grid
+            pol_slice = []
+            y_slices = np.linspace(ycoord, ycoordnext, refine_parallel_integral * 2 + 1)
+            if y_all is None:
+                y_all = y_slices[::-1]
+            else:
+                y_all = np.concatenate((y_all, y_slices[1:]))
+
+            tmp = np.array(
+                field_tracer.follow_field_lines(pol.R, pol.Z, y_slices, rtol=rtol)
+            )
+            if coords is None:
+                coords = tmp[::-1]
+            else:
+                coords = np.concatenate((coords, tmp[1:]))
+                if prog is not None:
+                    prog.update()
+
+        for k in range(3):
+            slc = slice(
+                refine_parallel_integral * k,
+                -refine_parallel_integral * (2 - k) if k < 2 else None,
+            )
+            sg_22[k][:, j, :] = field_line_length(coords[slc], y_all[slc])
+        coords = coords[refine_parallel_integral:-refine_parallel_integral]
+        y_all = y_all[refine_parallel_integral:-refine_parallel_integral]
+
+        Bs = [
+            magnetic_field.Byfunc(coord[..., 0], coord[..., 1], y)
+            for coord, y in zip(coords, y_all)
+        ]
+
+        B_cell[0][:, j, :] = Bs[0]
+        B_cell[1][:, j, :] = Bs[refine_parallel_integral]
+        B_cell[2][:, j, :] = Bs[-1]
+
+        facs = np.ones(refine_parallel_integral * 2 + 1)
+        assert len(y_all) == len(facs)
+        facs[0] = 0.5
+        facs[-1] = 0.5
+
+        metric = pol.metric()
+        Jperp0 = np.sqrt(metric["g_xx"] * metric["g_zz"] - metric["g_xz"] ** 2)
+        B0 = Bs[len(Bs) // 2]
+        vols = [
+            Jperp0 * B0 / Bpar * fac * R
+            for Bpar, fac, R in zip(Bs, facs, coords[..., 0])
+        ]
+        assert len(vols) == len(facs)
+        J = np.sum(vols, axis=0) / (len(Bs) - 1)
+        jacobian[:, j, :] = J
+
+        if prog is not None:
+            prog.update()
+
+    if not isinstance(magnetic_field, Slab):
+        maps["J"] = jacobian
+        for post, vals in zip(("_cell_ylow", "", "_cell_yhigh"), sg_22):
+            maps[f"Ly{post}"] = vals
+    for post, vals in zip(("_cell_ylow", "", "_cell_yhigh"), B_cell):
+        maps[f"By{post}"] = vals
     return maps
 
 
@@ -194,7 +300,8 @@ def update_metric_names(metric):
     # Translate between output variable names and metric names
     # Map from new to old names. Anything not in this dict
     # is unchanged
-    name_changes = {
+    name_changes = {}
+    for k, v in {
         "g_yy": "g_22",
         "gyy": "g22",
         "gxx": "g11",
@@ -203,7 +310,10 @@ def update_metric_names(metric):
         "g_xx": "g_11",
         "g_xz": "g_13",
         "g_zz": "g_33",
-    }
+    }.items():
+        for post in "", "_cell_ylow", "_cell_yhigh":
+            name_changes[k + post] = v + post
+
     return {name_changes.get(key, key): value for key, value in metric.items()}
 
 
@@ -242,7 +352,7 @@ def get_metric(grid, magnetic_field):
     metric["B"] = Bmag
     metric["pressure"] = pressure
 
-    # B * J / sqrt(g22)
+    # compute B * J / sqrt(g22)
     BJg = Bmag * np.sqrt(metric["g_xx"] * metric["g_zz"] - metric["g_xz"] ** 2)
 
     return metric, BJg
@@ -254,7 +364,7 @@ class MapWriter:
         mw.add_grid_field(grid, field)
         ...
         # Add some additional things
-        mw.add_dict(dict(a=f3d, b=f3d))
+        mw.write_dict(dict(a=f3d, b=f3d))
         ...
         mw.add_maps(maps)
         mw.add_dagp()
@@ -318,11 +428,6 @@ class MapWriter:
             R[:, j, :] = pol.R
             Z[:, j, :] = pol.Z
         self.write_dict(dict(R=R, Z=Z))
-        del R
-        del Z
-
-        if self.field:
-            self._write_metric()
 
     def add_dagp(self):
         """Add the coefficient for the finite-volume div-a-grad-perp implementation suitable for FCI."""
@@ -330,6 +435,9 @@ class MapWriter:
 
         assert self.grid, "The grid is needed to compute the DAGP. Set the grid first."
         assert self.is_open, "The grid file needs to be open. Call open first."
+        assert (
+            self.field
+        ), "The field is needed to compute the DAGP. Set the grid first."
         handles = {}
 
         poloidal_grids = self.grid.poloidal_grids
@@ -341,20 +449,19 @@ class MapWriter:
                 # See if the variable already exists
                 return self.f.impl.handle.variables[k]
             except KeyError:
-                # t = v.dtype.str
-                # dims = ("x", "y", "z")
                 var = self.f.impl.handle.createVariable(k, t, dims)
                 if init is not None:
                     var[:] = init
                 return var
 
+        isSlab = isinstance(self.field, Slab)
         i = np.int32(0)
         prog = getHandle("_dagp_generation_progress", i.dtype.str, (), init=i)
 
         for ind, pol in enumerate(poloidal_grids):
             if ind < prog[0]:
                 continue
-            dagp = doit([pol])
+            dagp = doit([pol], isSlab=isSlab)
             for k, v in dagp.items():
                 if k not in handles:
                     handles[k] = getHandle(k, v.dtype.str)
@@ -365,8 +472,6 @@ class MapWriter:
     def add_field(self, field):
         """Add the information from the field to the grid"""
         self.field = field
-        if self.grid:
-            self._write_metric()
 
     def add_grid_field(self, grid, field):
         """Add the information from the grid and the field to the grid file.
@@ -378,12 +483,20 @@ class MapWriter:
         self.add_field(field)
         self.add_grid(grid)
 
-    def _write_metric(self):
+    def _write_metric(self, maps):
         if self.metric_done:
             return
 
         metric, self.BJg = get_metric(self.grid, self.field)
 
+        if "Ly" in maps:
+            metric["g_yy_old"] = metric["g_yy"]
+            for post in "", "_cell_ylow", "_cell_yhigh":
+                metric[f"g_yy{post}"] = (maps[f"Ly{post}"] / metric["dy"]) ** 2
+            metric["g_yy_correct"] = (maps["Ly"] / metric["dy"]) ** 2
+        else:
+            for post in "_cell_ylow", "_cell_yhigh":
+                metric[f"g_yy{post}"] = metric["g_yy"]
         if not self.new_names:
             metric = update_metric_names(metric)
 
@@ -405,7 +518,7 @@ class MapWriter:
 
     def write_dict(self, metric, always3d=True):
         """
-        Add  data to the grid file"""
+        Add data to the grid file"""
 
         assert self.is_open, "File needs to be open. Call open first."
         # Metric is now 3D
@@ -434,20 +547,21 @@ class MapWriter:
         ny = len(ypar)
         meandy = np.mean(np.diff(ypar))
         Ly = self.grid.Ly if self.grid else meandy * ny
-        if self.grid:
+        if self.grid and len(ypar) > 1:
             assert np.isclose(
                 Ly, meandy * ny
             ), f"Ly of grid (Ly={Ly}) does not seem to match the average dy (ny * dy = {ny} * {meandy} = {ny * meandy}"
         yperiodic = self.grid.yperiodic if self.grid else True
         for offset in chain(range(1, nslice + 1), range(-1, -(nslice + 1), -1)):
-            pypar = np.roll(ypar, -offset)  # TODO: is the sign correct?
+            pypar = np.roll(ypar, -offset)
             if yperiodic:
                 for i in range(1, ny):
                     if meandy * (pypar[i] - pypar[i - 1]) < 0:
                         pypar[i] += np.sign(meandy) * Ly
-                assert np.isclose(
-                    np.mean(np.diff(pypar)), meandy
-                ), f"Mean of dy changes from {meandy} to {np.mean(np.diff(pypar))}. Values: {ypar} -> {pypar}"
+                if len(pypar) > 1:
+                    assert np.isclose(
+                        np.mean(np.diff(pypar)), meandy
+                    ), f"Mean of dy changes from {meandy} to {np.mean(np.diff(pypar))}. Values: {ypar} -> {pypar}"
 
             RZ = np.array([maps[parallel_slice_field_name(k, offset)] for k in "RZ"])
             par_pgrids = [StructuredPoloidalGrid(*RZ[:, :, i]) for i in range(ny)]
@@ -488,6 +602,9 @@ class MapWriter:
             for k in "RZ":
                 n = parallel_slice_field_name(k, offset)
                 keep[n] = maps[n]
+        assert self.field, "Ensure field is set before calling add_maps"
+        assert self.grid, "Ensure grid is set before calling add_maps"
+        self._write_metric(maps)
         del maps
         ypar = self.grid.ycoords
         self._write_par_metric(keep, nslice, ypar)


### PR DESCRIPTION
## Problem

For simple geometries, the old metric treatment is often good enough.

For a Dommaschk field, it is too optimistic about the distance travelled along the magnetic field between neighboring toroidal slices. In plain terms, the old metric assumes a shorter and simpler path than the field line actually takes in 3D.

That matters because the grid volume depends on the parallel part of the metric. If that parallel distance is underestimated, then the resulting metric and Jacobian are less faithful to the real Dommaschk geometry.

## Visual Summary

### 3D before/after

The old metric treats the parallel path between toroidal slices as shorter than it really is. The traced metric captures the longer field-line path in the Dommaschk geometry.

<img width="3520" height="1100" alt="dommaschk_parallel_3d_before_after" src="https://github.com/user-attachments/assets/86bb0fd9-a021-469d-a2d0-80bf3840dfdb" />


### Poloidal-plane before/after

On a representative slice, the old metric locally underestimates the parallel cell length. The traced metric increases it where the Dommaschk geometry bends more strongly.

<img width="3300" height="1056" alt="dommaschk_parallel_plane_before_after" src="https://github.com/user-attachments/assets/1a2f4581-027b-4657-a054-1879b2edce30" />


### Volume error comparison

Once the parallel metric is traced instead of approximated, the grid volume from `J * dx * dy * dz` moves closer to the true geometric Dommaschk volume.

<img width="1496" height="1100" alt="dommaschk_volume_error_before_after" src="https://github.com/user-attachments/assets/68078864-6afa-4cee-b605-d4c3672c9894" />


## What This PR Changes

This PR keeps only the Dommaschk-relevant metric part of `better-metric`.

It does three things:

1. Adds a helper to measure the length of a traced field-line segment in 3D.
2. Uses that traced parallel length when constructing the exported grid metric.
3. Adds a Dommaschk regression test that checks the grid volume against a geometric reference volume.

## Why This Helps The Dommaschk Case

The main improvement is that the parallel metric is no longer based only on a simpler local estimate.

Instead, it is measured from the traced field line itself.

For Dommaschk, that is the right thing to do because the field-line path between slices is genuinely three-dimensional. The old approach effectively treats that path as shorter and simpler than it really is. This PR replaces that optimistic estimate with the traced path length, so the exported metric and Jacobian better represent the real geometry.

The practical consequence is that the grid volume computed from the exported metric agrees better with the true Dommaschk volume.

## Code Changes

### `zoidberg/diff.py`

Adds `field_line_length(...)`, which converts traced field-line points into a physical 3D arc length.

### `zoidberg/zoidberg.py`

This is the core change.

- It adds half-step parallel targets and refined tracing in `make_maps(...)`.
- It computes traced parallel lengths and improved Jacobian data from those traced paths.
- It writes the corrected parallel metric terms into the exported grid.

This reduced branch keeps that logic self-contained in `zoidberg.py`, so it does not need the separate `grid.py` changes from the larger `better-metric` branch.

### `zoidberg/test_volume_dommaschk.py`

Adds a Dommaschk-specific regression test.

The test compares:
- a geometric/reference Dommaschk volume, and
- the grid volume computed from `J * dx * dy * dz`

The point of the test is to show that the traced metric improves the geometric fidelity of the exported grid for the Dommaschk case.

## Validation

Ran:

```bash
/opt/local/bin/python -m pytest -q zoidberg/test_volume_dommaschk.py
```

Result:

```text
1 passed, 1 warning in ~78s
```

The warning is only from xarray trying to load the optional `bout_adios2` backend without `adios2` installed.

## Why This PR Is Smaller Than `better-metric`

`better-metric` mixes several themes together:
- metric and Jacobian changes
- slab DAGP support
- `ny=1` support
- `findIndex()` behavior changes
- FusionSC integration
- dependency and test extras

This PR intentionally keeps only the part that is validated for the Dommaschk use case, so it is much easier to review.
